### PR TITLE
TCPTransport fixes

### DIFF
--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -125,9 +125,7 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             let wsReq = HTTPWSHeader.createUpgrade(request: request, supportsCompression: framer.supportsCompression(), secKeyValue: secKeyValue)
             let data = httpHandler.convert(request: wsReq)
             transport.write(data: data, completion: {_ in })
-        case .waiting:
-            break
-        case .failed(let error):
+        case .waiting(let error), .failed(let error):
             handleError(error)
         case .viability(let isViable):
             broadcast(event: .viabilityChanged(isViable))

--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -125,7 +125,9 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             let wsReq = HTTPWSHeader.createUpgrade(request: request, supportsCompression: framer.supportsCompression(), secKeyValue: secKeyValue)
             let data = httpHandler.convert(request: wsReq)
             transport.write(data: data, completion: {_ in })
-        case .waiting(let error), .failed(let error):
+        case .waiting:
+            break
+        case .failed(let error):
             handleError(error)
         case .viability(let isViable):
             broadcast(event: .viabilityChanged(isViable))

--- a/Sources/Framer/HTTPHandler.swift
+++ b/Sources/Framer/HTTPHandler.swift
@@ -70,7 +70,7 @@ public struct HTTPWSHeader {
             let val = "permessage-deflate; client_max_window_bits; server_max_window_bits=15"
             req.setValue(val, forHTTPHeaderField: HTTPWSHeader.extensionName)
         }
-        let hostValue = req.allHTTPHeaderFields?[HTTPWSHeader.hostName] ?? "\(parts.host):\(parts.port)"
+        let hostValue = req.allHTTPHeaderFields?[HTTPWSHeader.hostName] ?? "\(parts.host)"
         req.setValue(hostValue, forHTTPHeaderField: HTTPWSHeader.hostName)
         return req
     }

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -110,8 +110,8 @@ public class TCPTransport: Transport {
             switch newState {
             case .ready:
                 self?.delegate?.connectionChanged(state: .connected)
-            case .waiting:
-                self?.delegate?.connectionChanged(state: .waiting)
+            case .waiting(let error):
+                self?.delegate?.connectionChanged(state: .waiting(error))
             case .cancelled:
                 self?.delegate?.connectionChanged(state: .cancelled)
             case .failed(let error):

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -115,12 +115,10 @@ public class TCPTransport: Transport {
             case .ready:
                 self?.removeTimeoutTimer()
                 self?.delegate?.connectionChanged(state: .connected)
-            case .waiting(let error):
-                self?.delegate?.connectionChanged(state: .waiting(error))
+            case .waiting(let error), .failed(let error):
+                self?.delegate?.connectionChanged(state: .failed(error))
             case .cancelled:
                 self?.delegate?.connectionChanged(state: .cancelled)
-            case .failed(let error):
-                self?.delegate?.connectionChanged(state: .failed(error))
             case .setup, .preparing:
                 break
             @unknown default:

--- a/Sources/Transport/Transport.swift
+++ b/Sources/Transport/Transport.swift
@@ -26,7 +26,7 @@ import Foundation
 
 public enum ConnectionState {
     case connected
-    case waiting
+    case waiting(Error?)
     case cancelled
     case failed(Error?)
     

--- a/Starscream.podspec
+++ b/Starscream.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Starscream"
-  s.version      = "4.0.10"
+  s.version      = "4.0.11"
   s.summary      = "A conforming WebSocket RFC 6455 client library in Swift."
   s.homepage     = "https://github.com/daltoniam/Starscream"
   s.license      = 'Apache License, Version 2.0'


### PR DESCRIPTION
- Implement a timeout for `TCPTransport` ([Apple response reference](https://forums.developer.apple.com/forums/thread/728130?answerId=750633022#750633022)).
- Handle POSIX timeout errors the same way as `NWConnection` by using the `.waiting` state.
- Exclude the redundant port from the `Host`, as it prevents some nodes from connecting.
